### PR TITLE
Declare Dynamic Parameters without RuntimeDefinedParameterDictionary

### DIFF
--- a/src/System.Management.Automation/engine/CommandBase.cs
+++ b/src/System.Management.Automation/engine/CommandBase.cs
@@ -69,6 +69,11 @@ namespace System.Management.Automation.Internal
         /// <value></value>
         internal IScriptExtent InvocationExtent { get; set; }
 
+        /// <summary>
+        /// Allows you to access the AST for this command invocation...
+        /// </summary>
+        internal CommandAst InvocationAst { get; set; }
+
         private InvocationInfo _myInvocation = null;
         /// <summary>
         /// Return the invocation data object for this command.

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -2404,60 +2404,89 @@ namespace System.Management.Automation
             }
         }
 
+        /// <summary>
+        /// Gets a ScriptBlock's Dynamic Parameters 
+        /// </summary>
+        /// <returns>A dictionary of dynamic parameters.</returns>
         public object GetDynamicParameters()
         {
-            _commandRuntime = (MshCommandRuntime)commandRuntime;
-
-            if (_scriptBlock.HasDynamicParameters)
-            {
-                var resultList = new List<object>();
-                Diagnostics.Assert(_functionContext._outputPipe == null, "Output pipe should not be set yet.");
-                _functionContext._outputPipe = new Pipe();
-                var objectStream = new ObjectStream();
-                var objectWriter = new ObjectWriter(objectStream);
-                objectStream.DataReady += (sender, args) =>
-                {
-                    var objectStream = sender as ObjectStream;
-                    while (objectStream.Count > 0)
-                    {
-                        var obj = objectStream.Read();
-                        RuntimeDefinedParameter runtimeDefinedParameter = obj as RuntimeDefinedParameter;
-                        runtimeDefinedParameter ??= (obj as PSObject)?.BaseObject as RuntimeDefinedParameter;
-                        if (runtimeDefinedParameter is RuntimeDefinedParameter)
-                        {
-                            RuntimeDefinedParameterDictionary runtimeParamDictionary = new() { { runtimeDefinedParameter.Name, runtimeDefinedParameter } };
-                            _parameterBinderController.MergeStaticAndDynamicParameterMetadata(runtimeParamDictionary);
-                            ParameterBindingException outgoingBindingException = null;
-                            _parameterBinderController.BindDynamicParameters(out outgoingBindingException);
-                            if (outgoingBindingException != null)
-                            {
-                                throw outgoingBindingException;
-                            }
-                            if (this.MyInvocation.BoundParameters.TryGetValue(runtimeDefinedParameter.Name, out var boundValue))
-                                this.SessionState.PSVariable.Set(runtimeDefinedParameter.Name, boundValue);
-                        }
-                        else
-                        {
-                            resultList.Add(obj);
-                        }
-                    }
-                };
-                _functionContext._outputPipe.ExternalWriter = objectWriter;
-                RunClause(
-                    clause: _runOptimized ? _scriptBlock.DynamicParamBlock : _scriptBlock.UnoptimizedDynamicParamBlock,
-                    dollarUnderbar: AutomationNull.Value,
-                    inputToProcess: AutomationNull.Value);
-                if (resultList.Count > 1)
-                {
-                    throw PSTraceSource.NewInvalidOperationException(
-                        AutomationExceptions.DynamicParametersWrongType,
-                        PSObject.ToStringParser(this.Context, resultList));
-                }
-
-                return resultList.Count == 0 ? null : PSObject.Base(resultList[0]);
+            // If there is not a dynamicParam block,
+            if (!_scriptBlock.HasDynamicParameters) {                
+                return null; // return nothing, since it cannot have dynamic parameters.
             }
 
-            return null;
+            // In order to bind dynamic parameters as soon as possible, we want to capture each output of the dynamic param block.
+            _commandRuntime = (MshCommandRuntime)commandRuntime;                        
+            var resultList = new List<object>();
+            // this works because normally the dynamic parameter block does not output to the pipeline
+            // (hence, no output pipe should already exist).
+            Diagnostics.Assert(_functionContext._outputPipe == null, "Output pipe should not be set yet.");
+
+            // So let's create one.
+            _functionContext._outputPipe = new Pipe();
+            var objectStream = new ObjectStream();
+            var objectWriter = new ObjectWriter(objectStream);        
+            _functionContext._outputPipe.ExternalWriter = objectWriter;
+            
+            // and also create a dictionary to accumulate dynamic parameters.
+            RuntimeDefinedParameterDictionary accumulatedDynamicParameters = new RuntimeDefinedParameterDictionary();
+            
+            // As data comes thru the output pipe
+            objectStream.DataReady += (sender, args) =>
+            {
+                var objectStream = sender as ObjectStream;
+                while (objectStream.Count > 0)
+                {
+                    // read each output
+                    var obj = objectStream.Read();
+                    // If it could be a RuntimeDefinedParameter
+                    RuntimeDefinedParameter runtimeDefinedParameter = obj as RuntimeDefinedParameter;
+                    // get a reference to the base object (since almost everything in PowerShell is wrapped in a PSObject)
+                    runtimeDefinedParameter ??= (obj as PSObject)?.BaseObject as RuntimeDefinedParameter;
+                    // If we could not cast to a runtime parameter
+                    if (!(runtimeDefinedParameter is RuntimeDefinedParameter))
+                    {
+                        // pass the result back thru
+                        resultList.Add(obj);
+                    } else 
+                    {
+                        // otherwise, accumulate that dynamic parameter.                       
+                        accumulatedDynamicParameters.Add(runtimeDefinedParameter.Name, runtimeDefinedParameter);
+                    }
+                }
+            };
+
+            // We want to provide dynamicParams with as much context as we can.
+            CommandAst commandAst = this.InvocationAst;
+                        
+            RunClause(
+                // Now we run the dynamic parameter block (which will trigger ObjectStream.DataReady).    
+                clause: _runOptimized ? _scriptBlock.DynamicParamBlock : _scriptBlock.UnoptimizedDynamicParamBlock,
+                // $_ should be the command with dynamic parameters
+                dollarUnderbar: this.MyInvocation.MyCommand, 
+                // $Input will be the CommandAST's elements (thus giving dynamicParam enough context to be conditional)
+                inputToProcess: commandAst != null ? commandAst.CommandElements : AutomationNull.Value 
+            );
+
+            // If more than one result is being outputted
+            if (resultList.Count > 1)
+            {
+                // then they have provided two properties, and we will throw
+                throw PSTraceSource.NewInvalidOperationException(
+                    AutomationExceptions.DynamicParametersWrongType,
+                    PSObject.ToStringParser(this.Context, resultList));
+            }
+
+            // If only one result was provided
+            if (resultList.Count == 1) {
+                return resultList[0]; // return that
+            } else if (accumulatedDynamicParameters.Count >= 1) {
+                // If one or more parameter was accumulated, return them.
+                return accumulatedDynamicParameters;
+            } else {
+                // Otherwise, return nothing.
+                return null;
+            }
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -28,6 +28,16 @@ namespace System.Management.Automation
 {
     internal static class PipelineOps
     {
+        /// <summary>
+        /// This method adds commands to be processed by PowerShell.
+        /// It is called while evaluating PowerShell and is responsible for command resolution and argument assignment.
+        /// </summary>
+        /// <param name="pipe">The pipeline processor.</param>
+        /// <param name="commandElements">The command elements.</param>
+        /// <param name="commandBaseAst">The current command's base AST.</param>
+        /// <param name="redirections">Any command redirections.</param>
+        /// <param name="context">The context used to execute the command.</param>
+        /// <returns></returns>
         private static CommandProcessorBase AddCommand(PipelineProcessor pipe,
                                                        CommandParameterInternal[] commandElements,
                                                        CommandBaseAst commandBaseAst,
@@ -207,8 +217,13 @@ namespace System.Management.Automation
             {
                 commandProcessor = CommandProcessorBase.CreateGetHelpCommandProcessor(context, helpTarget, helpCategory);
             }
-
+            
+            // This is roughly where scripts are wired up to their current invocation
+            // we were already tracking the extent of the AST.
             commandProcessor.Command.InvocationExtent = commandBaseAst.Extent;
+            // in order to enable additional context in dynamic parameters, we will attach the ast to the InternalCommand.
+            // This will likely be useful for other scenarios as well, since it saves the time and effort of performing a callstack peek.
+            commandProcessor.Command.InvocationAst = commandAst;
             commandProcessor.Command.MyInvocation.ScriptPosition = commandBaseAst.Extent;
             commandProcessor.Command.MyInvocation.InvocationName = invocationName;
 

--- a/test/powershell/Language/Scripting/Dynamicparameters.Tests.ps1
+++ b/test/powershell/Language/Scripting/Dynamicparameters.Tests.ps1
@@ -1,85 +1,182 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-Describe "Dynamic parameter support in script cmdlets." -Tags "CI" {
-    BeforeAll {
-        Class MyTestParameter {
-            [parameter(ParameterSetName = 'pset1', position = 0, mandatory = 1)]
-            [string] $name
+Describe "Dynamic parameters" -Tags "CI" {
+    context "Dynamic Parameter Basics" {
+        BeforeAll {
+            function Test-DynamicParameterBasics {
+                [CmdletBinding()]
+                param()
+
+                dynamicParam {
+                    $dynamicParams = [Management.Automation.RuntimeDefinedParameterDictionary]::new()
+                    $dynamicParams.Add(
+                        "Foo", [Management.Automation.RuntimeDefinedParameter]::new(
+                            "Foo",
+                            [int],
+                            @(
+                                $parameter = [Parameter]::new()
+                                $parameter.Mandatory = $true
+                                $parameter.Position = 0
+                                $parameter
+                            )
+                        )
+                    )
+                    $dynamicParams.Add(
+                        "Bar", [Management.Automation.RuntimeDefinedParameter]::new(
+                            "Bar",
+                            [string],
+                            @(
+                                $parameter = [Parameter]::new()
+                                $parameter.Position = 1
+                                $parameter
+                            )
+                        )
+                    )
+                    $dynamicParams
+                }
+
+                process {
+                    [PSCustomObject]([Ordered]@{} + $PSBoundParameters)
+                }
+            }
+        }
+        it "Will bind to dynamic parameters" {
+            $output = Test-DynamicParameterBasics -Foo 1 -bar 2
+            $output.Foo | Should -be 1
+            $output.bar | Should -be 2
         }
 
-        function foo-bar {
-            [CmdletBinding()]
-            param($path)
-
-            dynamicparam {
-                if ($PSBoundParameters["path"] -contains "abc") {
-                    $attributes = [System.Management.Automation.ParameterAttribute]::New()
-                    $attributes.ParameterSetName = 'pset1'
-                    $attributes.Mandatory = $false
-
-                    $attributeCollection = [System.Collections.ObjectModel.Collection``1[System.Attribute]]::new()
-                    $attributeCollection.Add($attributes)
-
-                    $dynParam1 = [System.Management.Automation.RuntimeDefinedParameter]::new("dp1", [Int32], $attributeCollection)
-                    if ($PSBoundParameters["path"] -contains "realtime") {
-                        return $dynParam1
-                    } else {
-                        $paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
-                        $paramDictionary.Add("dp1", $dynParam1)
-
-                        return $paramDictionary
-                    }
-                } elseif ($PSBoundParameters["path"] -contains "class") {
-                    $paramDictionary = [MyTestParameter]::new()
-                    return $paramDictionary
-                }
-
-                $paramDictionary = $null
-                return $null
-            }
-
-            begin {
-                if($dp1){
-                    return $dp1
-                }
-                if (($null -ne $paramDictionary) -and ($paramDictionary -is [MyTestParameter]) ) {
-                    $paramDictionary.name
-                } elseif ($null -ne $paramDictionary) {
-                    if ($null -ne $paramDictionary.dp1.Value) {
-                        $paramDictionary.dp1.Value
-                    } else {
-                        "dynamic parameters not passed"
-                    }
-                } else {
-                    "no dynamic parameters"
-                }
-            }
-
-            process {}
-            end {}
+        it "Will allow dynamic parameters to be accessed from .Parameters" {
+            (Get-Command Test-DynamicParameterBasics).Parameters["Foo"].Attributes |
+                Where-Object { $_.Mandatory -is [bool] } |
+                Select-Object -ExpandProperty Mandatory |
+                Should -Be $true
+            (Get-Command Test-DynamicParameterBasics).Parameters["Bar"] | Should -not -be $null
         }
     }
 
-    It "The dynamic parameter is enabled and bound" {
-        foo-bar -path abc -dp1 42 | Should -Be 42
+    context "Dynamic Parameters Using InvocationName" {
+        BeforeAll {
+            function Test-DynamicParameterWithSmartAlias {
+                [CmdletBinding()]
+                param()
+
+                dynamicParam {
+                    if ($MyInvocation.InvocationName -and
+                        ($MyInvocation.InvocationName -ne $MyInvocation.MyCommand.Name)) {
+                        $dynamicParams = [Management.Automation.RuntimeDefinedParameterDictionary]::new()
+                        $dynamicParams.Add(
+                        "$($MyInvocation.InvocationName)", [Management.Automation.RuntimeDefinedParameter]::new(
+                            "$($MyInvocation.InvocationName)",
+                            [switch],
+                            @(
+                                [Parameter]::new()
+                            )
+                        )
+                        )
+                        $dynamicParams
+                    }
+
+                }
+
+                process {
+                    [Ordered]@{} + $PSBoundParameters
+                }
+            }
+
+            Set-Alias AliasingWithDynamicParameters Test-DynamicParameterWithSmartAlias
+            Set-Alias ItIsPossibleToHaveMultipleAliasesToTheSameCommand Test-DynamicParameterWithSmartAlias
+            Set-Alias YouCanUseCommandNamesToInfluenceDynamicParameters Test-DynamicParameterWithSmartAlias
+        }
+
+        it "Can have different parameters depending on what it is called" {
+            AliasingWithDynamicParameters -AliasingWithDynamicParameters
+            ItIsPossibleToHaveMultipleAliasesToTheSameCommand -ItIsPossibleToHaveMultipleAliasesToTheSameCommand
+            YouCanUseCommandNamesToInfluenceDynamicParameters -YouCanUseCommandNamesToInfluenceDynamicParameters
+        }
     }
 
-    It "When the dynamic parameter is not available, and raises an error when specified" {
-        { foo-bar -path def -dp1 42 } | Should -Throw -ErrorId "NamedParameterNotFound,foo-bar"
-    }
+    context "Emitting Dynamic Parameters" {
+        BeforeAll {
 
-    It "No dynamic parameter shouldn't cause an errr " {
-        foo-bar -path def  | Should -BeExactly 'no dynamic parameters'
-    }
+            function Test-DynamicEmit {
+                [CmdletBinding()]
+                param($path)
 
-    It "Not specifying dynamic parameter shouldn't cause an error" {
-        foo-bar -path abc | Should -BeExactly 'dynamic parameters not passed'
-    }
+                dynamicparam {
+                    # $Input will contain the command elements of the current invocation.
+                    # $_ will be the current command.
 
-    It "Parameter is defined in Class" {
-        foo-bar -path class -Name "myName" | Should -BeExactly 'myName'
-    }
-    It "Parameter is bound without dictionary"{
-        foo-bar -path abc,realtime -dp1 42 | Should -Be 42
+                    # Simply emit a few dynamic parameters.
+                    # All dynamic emitted dynamic parameters will be joined into a dictionary.
+                    [Management.Automation.RuntimeDefinedParameter]::new(
+                        "Foo",
+                        [string],
+                        @([Parameter]::new())
+                    )
+
+                    [Management.Automation.RuntimeDefinedParameter]::new(
+                        "Bar",
+                        [string],
+                        @([Parameter]::new())
+                    )
+
+                    [Management.Automation.RuntimeDefinedParameter]::new(
+                        "Baz",
+                        [string],
+                        @([Parameter]::new())
+                    )
+                }
+
+                process {
+                    @($PSBoundParameters.Values)
+                }
+            }
+
+            function Test-DynamicConditionalEmit {
+                [CmdletBinding()]
+                param($path)
+
+                dynamicparam {
+                    # $Input will contain the command elements of the current invocation.
+                    # $_ will be the current command.
+                    $pathToBe = @($input)[1]
+
+                    # This is a simple and easily testable example, and not anywhere near complete parsing
+                    # (this check will only work if $Path is assigned positionally)
+                    if ($pathToBe -is [Management.Automation.Language.StringConstantExpressionAst]) {
+                        $pathToBe = $pathToBe.Value
+                    }
+
+                    # If the path is not explicitly "badPath"
+                    if ($pathToBe -ne "BadPath") {
+                        # create a dynamic parameter
+                        [Management.Automation.RuntimeDefinedParameter]::new(
+                            "foo",
+                            [int],
+                            @([Parameter]::new())
+                        )
+                    }
+                }
+
+                process {
+                    @($PSBoundParameters.Values)
+                }
+            }
+
+
+        }
+
+        it "Can emit dynamic parameters, rather than returning a RuntimeParameterDictionary" {
+            Test-DynamicEmit -Foo 1 -Bar 2 -Baz 3 | Should -Be @(1,2,3)
+        }
+
+        it "Can conditionally emit a parameter" {
+            Test-DynamicConditionalEmit -Foo 1 | Should -Be @(1)
+        }
+
+        it "Can conditionally _not_ emit a parameter" {
+            { Test-DynamicConditionalEmit badpath -Foo 1 -ErrorAction stop } | Should -Throw
+        }
     }
 }


### PR DESCRIPTION
* Removing binding.
* Adding useful context for DynamicParams ($_ is the command, $input is the CommandElements)
* Improving documentation.
* Adding tests.
